### PR TITLE
WindowsInstallerLib: enable EnableWindowsTargeting

### DIFF
--- a/WindowsInstallerLib/WindowsInstallerLib.csproj
+++ b/WindowsInstallerLib/WindowsInstallerLib.csproj
@@ -11,6 +11,7 @@
 	<LangVersion>latest</LangVersion>
 	<Version>1.0.0.0</Version>
 	<Platforms>x64</Platforms>
+	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Adds a missing flag for the library project needed for the Actions to work.