### PR TITLE
WindowsInstallerLib: remove leftover boolean from a function

### DIFF
--- a/WindowsInstallerLib/src/ProcessManager.cs
+++ b/WindowsInstallerLib/src/ProcessManager.cs
@@ -107,7 +107,7 @@ namespace WindowsInstallerLib.Management
             return ExitCode;
         }
 
-        internal static int StartDismProcess(string args, bool RunAsAdministrator = false)
+        internal static int StartDismProcess(string args)
         {
             Process process = new();
 


### PR DESCRIPTION
Forgot to delete RunAsAdministrator from the function StartDismProcess