### PR TITLE
Fix a crash when trying to choose installation disk

### DIFF
--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -8,7 +8,6 @@
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <LangVersion>latest</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <PublishAot>True</PublishAot>
     <ErrorReport>none</ErrorReport>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <StartupObject>ConsoleApp.Program</StartupObject>

--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
@@ -11,10 +11,12 @@
     <ErrorReport>none</ErrorReport>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <StartupObject>ConsoleApp.Program</StartupObject>
+    <SupportedOSPlatformVersion>10.0.26100.0</SupportedOSPlatformVersion>
+    <Version>0.0.4.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Version>0.0.4.0</Version>
+    <Version>0.0.4.1</Version>
     <VersionSuffix>testing</VersionSuffix>
     <DebugType>embedded</DebugType>
     <WarningLevel>9999</WarningLevel>
@@ -23,9 +25,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <AssemblyVersion>0.0.4.0</AssemblyVersion>
-    <FileVersion>0.0.4.0</FileVersion>
-    <Version>0.0.4.0</Version>
+    <AssemblyVersion>0.0.4.1</AssemblyVersion>
+    <FileVersion>0.0.4.1</FileVersion>
+    <Version>0.0.4.1</Version>
     <DebugType>none</DebugType>
     <WarningLevel>0</WarningLevel>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>

--- a/WindowsInstallerLib/WindowsInstallerLib.csproj
+++ b/WindowsInstallerLib/WindowsInstallerLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+        <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
         <Nullable>enable</Nullable>
         <SupportedOSPlatformVersion>10.0.22621.0</SupportedOSPlatformVersion>
         <PlatformTarget>x64</PlatformTarget>
@@ -9,7 +9,7 @@
         <ErrorReport>none</ErrorReport>
         <Title>$(AssemblyName)</Title>
         <LangVersion>latest</LangVersion>
-        <Version>1.1.0.0</Version>
+        <Version>1.1.0.1</Version>
         <Platforms>x64</Platforms>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>


### PR DESCRIPTION
This fixes a crash in the `System.Management` library. This resource uses built-in COM support but it is not compatible with trimming and it must be disabled. 