### PR TITLE
ConsoleApp: move unimportant stuff to another file

### DIFF
--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using System.Runtime.Versioning;
 using WindowsInstallerLib;
 
@@ -9,27 +8,21 @@ namespace ConsoleApp
     internal sealed class Program
     {
         [MTAThread]
-        internal static int Main(string[] args)
+        internal static int Main()
         {
+            InstallerParameters parameters = new();
+
             try
             {
-                string ProgramAuthor = "Ken Hoo";
-                string ProgramName = Assembly.GetExecutingAssembly().GetName().Name ?? "Windows CLI Installer";
+                ProgramInfo.GetInformation();
+            }
+            catch (Exception)
+            {
+                throw;
+            }
 
-                Version? ProgramVersion = Assembly.GetExecutingAssembly().GetName().Version;
-#if DEBUG
-                AssemblyConfigurationAttribute? ConfigurationAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>();
-
-                string? ConfigurationMode = ConfigurationAttribute?.Configuration;
-
-                Console.Title = $"[{ConfigurationMode?.ToString()}] {ProgramName}";
-                Console.WriteLine($"Welcome to the {ProgramName} tool!\nCurrent version: {ProgramVersion}-testing\nCreated by {ProgramAuthor}");
-#else
-                Console.Title = $"{ProgramName}";
-                Console.WriteLine($"Welcome to the {ProgramName} tool!\nCurrent version: {ProgramVersion}\nCreated by {ProgramAuthor}");
-#endif
-                InstallerParameters parameters = new();
-
+            try
+            {
                 InstallerManager.ConfigureInstaller(ref parameters);
 
                 InstallerManager.InstallWindows(ref parameters);

--- a/ConsoleApp/ProgramInfo.cs
+++ b/ConsoleApp/ProgramInfo.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+
+namespace ConsoleApp
+{
+    internal sealed class ProgramInfo
+    {
+        internal static void GetInformation()
+        {
+            const string ProgramAuthor = "Ken Hoo";
+            string ProgramName = Assembly.GetExecutingAssembly().GetName().Name ?? "Windows CLI Installer";
+
+            Version? ProgramVersion = Assembly.GetExecutingAssembly().GetName().Version;
+#if DEBUG
+            AssemblyConfigurationAttribute? ConfigurationAttribute = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyConfigurationAttribute>();
+
+            string? ConfigurationMode = ConfigurationAttribute?.Configuration;
+
+            Console.Title = $"[{ConfigurationMode?.ToString()}] {ProgramName}";
+            Console.WriteLine($"Welcome to the {ProgramName} tool!\nCurrent version: {ProgramVersion}-testing\nCreated by {ProgramAuthor}");
+#else
+                Console.Title = $"{ProgramName}";
+                Console.WriteLine($"Welcome to the {ProgramName} tool!\nCurrent version: {ProgramVersion}\nCreated by {ProgramAuthor}");
+#endif
+        }
+    }
+}


### PR DESCRIPTION
- Create a ProgramInfo class in a new file and move stuff like information, configuration mode, etc into a seperate file.