### PR TITLE
Fix a bug preventing some prompts from showing up

### DIFF
--- a/ConsoleApp/ConsoleApp.csproj
+++ b/ConsoleApp/ConsoleApp.csproj
@@ -12,7 +12,7 @@
     <ErrorReport>none</ErrorReport>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <StartupObject>ConsoleApp.Program</StartupObject>
-    <Version>0.0.6.2</Version>
+    <Version>0.0.6.3</Version>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>

--- a/ConsoleApp/Program.cs
+++ b/ConsoleApp/Program.cs
@@ -10,7 +10,11 @@ namespace ConsoleApp
         [MTAThread]
         internal static int Main(string[] args)
         {
-            Parameters parameters = new();
+            Parameters parameters = new()
+            {
+                DiskNumber = -1,
+                ImageIndex = -1,
+            };
 
             try
             {

--- a/WindowsInstallerLib/WindowsInstallerLib.csproj
+++ b/WindowsInstallerLib/WindowsInstallerLib.csproj
@@ -8,7 +8,7 @@
         <ErrorReport>none</ErrorReport>
         <Title>$(AssemblyName)</Title>
         <LangVersion>latest</LangVersion>
-        <Version>1.1.2.1</Version>
+        <Version>1.1.2.2</Version>
         <Platforms>x64</Platforms>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>

--- a/WindowsInstallerLib/src/InstallerManager.cs
+++ b/WindowsInstallerLib/src/InstallerManager.cs
@@ -139,7 +139,8 @@ namespace WindowsInstallerLib
 
             #region DiskNumber
             if (string.IsNullOrEmpty(parameters.DiskNumber.ToString()) ||
-                string.IsNullOrWhiteSpace(parameters.DiskNumber.ToString()))
+                string.IsNullOrWhiteSpace(parameters.DiskNumber.ToString()) ||
+                parameters.DiskNumber == -1)
             {
                 int p_DiskNumber;
 
@@ -236,7 +237,8 @@ namespace WindowsInstallerLib
 
             #region ImageIndex
             if (string.IsNullOrEmpty(parameters.ImageIndex.ToString()) ||
-                string.IsNullOrWhiteSpace(parameters.ImageIndex.ToString()))
+                string.IsNullOrWhiteSpace(parameters.ImageIndex.ToString()) ||
+                parameters.ImageIndex == -1)
             {
                 DeployManager.GetImageInfo(ref parameters);
 


### PR DESCRIPTION
Due to the variables DiskNumber and ImageIndex getting initialized to 0, the prompts to set these, never show up. This PR hopefully fixes this.