### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: .NET
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/felgmar/wcit/security/code-scanning/1](https://github.com/felgmar/wcit/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Based on the workflow's steps, it appears that only read access to the repository contents is required. Therefore, the `permissions` block should specify `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
